### PR TITLE
Change the title of the webpage

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RegistryApiRails</title>
+    <title>Buildpack Registry</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
It now says "Buildpack Registry" in the browser tab.