### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 The Cloud Native Buildpacks Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
> The codebase clearly uses the Apache 2 license which is great for folks who want to build off of it, but the LICENSE file included with the repo still has the placeholder copyright from the license template. This makes it difficult to provide proper attribution.

This was pointed out in https://github.com/buildpacks/pack/issues/813, and resolved in pack in https://github.com/buildpacks/pack/pull/1053

