### PR TITLE
Display "Unknown" for empty license info in packs detail page

### DIFF
--- a/app/javascript/components/buildpack/Detail.tsx
+++ b/app/javascript/components/buildpack/Detail.tsx
@@ -66,7 +66,7 @@ class Detail extends React.Component<{match: {params: any}}, { buildpack: any }>
                     License
                 </Card.Title>
                 <Card.Text>
-                    {this.state.buildpack.latest.license}
+                    {this.state.buildpack.latest.license ?? 'Unknown'}
                 </Card.Text>
             </div>;
         }


### PR DESCRIPTION
## Changes
- Display "Unknown" if license info is falsy.

![image](https://user-images.githubusercontent.com/34343421/107681950-bf5f8f00-6cc5-11eb-83c0-5a9e4b2f20ba.png)
Fixes #20 