### PR TITLE
Make details page responsive

### DIFF
--- a/app/javascript/components/buildpack/Detail.scss
+++ b/app/javascript/components/buildpack/Detail.scss
@@ -29,14 +29,15 @@ div > a {
 
 code {
     font-family: monospace,monospace;
-    height: 3em;
+    min-height: 3em;
     display: flex;
     background-color: lightgray;
     color: black;
     border-radius: 5px;
     font-size: 1.1em;
     padding: 12px;
-    width: 45em;
+    max-width: 45em;
+    word-break: break-all;
 }
 
 .Buildpack-details-meta {
@@ -54,10 +55,18 @@ code {
 .Buildpack-details-supported-stack-item {
     font-size: .8em;
     color: #252960;
+    word-break: break-all;
+    border-left-width: 1px !important;
 }
 
 .Buildpack-homepage-icon {
     width: 2em;
     height: 2em;
     margin-top: -0.5em;
+}
+
+.list-group-horizontal {
+    display: flex;
+    justify-content: flex-start;
+    flex-flow: row wrap;
 }


### PR DESCRIPTION
## Changes
- Made code blocks responsive
- Break supported stacks list group into new lines when necessary (using flexbox)

Old:
![old_image](https://user-images.githubusercontent.com/34343421/107975426-1921cb00-6fde-11eb-8133-669f4cdd219d.png)

New:
![new_image](https://user-images.githubusercontent.com/34343421/107975464-276fe700-6fde-11eb-9c43-4ad34ca97fab.png)

Desktop view still looks the same:
![desktop_image](https://user-images.githubusercontent.com/34343421/107975500-36ef3000-6fde-11eb-8ff3-fdf6fd3e0094.png)

Fixes #31 