### PR TITLE
Add links to Home and Docs

### DIFF
--- a/app/javascript/components/common/Header.tsx
+++ b/app/javascript/components/common/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import logo from './logo-bug.svg';
 import Navbar from 'react-bootstrap/Navbar';
+import Nav from 'react-bootstrap/Nav';
 import './Header.scss';
 import { Container } from 'react-bootstrap';
 
@@ -14,6 +15,12 @@ class Header extends React.Component<any, any> {
                             <a href="/"><img src={logo} alt="Buildpacks" /></a><span>Registry</span>
                         </Navbar.Brand>
                         <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+                        <Navbar.Collapse>
+                            <Nav className="ml-auto">
+                                <Nav.Link href="https://buildpacks.io/" rel="nofollow noopener noreferrer" target="_blank">Home</Nav.Link>
+                                <Nav.Link href="https://buildpacks.io/docs/buildpack-author-guide/publish-a-buildpack/" rel="nofollow noopener noreferrer" target="_blank">Docs</Nav.Link>
+                            </Nav>
+                        </Navbar.Collapse>
                     </Navbar>
                 </Container>
             </header>


### PR DESCRIPTION
## Changes
- Added a link to Home (https://buildpacks.io/), opens in a new tab.
- Added a link to Docs (https://buildpacks.io/docs/buildpack-author-guide/publish-a-buildpack/), opens in a new tab.

Desktop view:
![image](https://user-images.githubusercontent.com/34343421/108136060-499d5e00-70df-11eb-8fc9-d6ce0012f2e6.png)

Mobile view (expanded):
![image](https://user-images.githubusercontent.com/34343421/108136183-8cf7cc80-70df-11eb-8473-43bc14a0b4d4.png)

Fixes #28 Fixes #30 