### PR TITLE
Fix bug in collecting license types for index cache

### DIFF
--- a/cmd/index-buildpacks/main.go
+++ b/cmd/index-buildpacks/main.go
@@ -193,8 +193,8 @@ DO
 	}
 
 	var licenses []string
-	for _, s := range m.Licenses {
-		stacks = append(stacks, s.Type)
+	for _, l := range m.Licenses {
+		licenses = append(licenses, l.Type)
 	}
 
 	version := strings.Split(m.Version, ".")


### PR DESCRIPTION
This bug was resulting in stuff like:

![image](https://user-images.githubusercontent.com/1589/108237734-d0692f80-710d-11eb-877f-b319147d203b.png)
