### PR TITLE
Fix licenses bug in details page

### DIFF
--- a/app/javascript/components/buildpack/Detail.tsx
+++ b/app/javascript/components/buildpack/Detail.tsx
@@ -69,7 +69,7 @@ class Detail extends React.Component<{match: {params: any}}, { buildpack: any }>
                     License
                 </Card.Title>
                 <Card.Text>
-                    {this.state.buildpack.latest.license ?? 'Unknown'}
+                    {this.state.buildpack.latest.licenses?.join(', ') ?? 'Unknown'}
                 </Card.Text>
             </div>;
         }


### PR DESCRIPTION
The details page was incorrectly using the variable `buildpack.latest.license` instead of `buildpack.latest.licenses` which caused the page to always show the license info is unknown.

## Changes
- Fix variable name
- Display licenses comma separated

![None](https://user-images.githubusercontent.com/34343421/108331831-2b298680-71f5-11eb-95b3-6c963b70d9a2.png) ![Single](https://user-images.githubusercontent.com/34343421/108331886-37addf00-71f5-11eb-9f7b-51a1b45f6428.png) ![Multiple](https://user-images.githubusercontent.com/34343421/108331784-1e0c9780-71f5-11eb-8d5d-6236251f84a0.png)
