### PR TITLE
Replace host in Rails controller with env var

### DIFF
--- a/app/controllers/api/v1/buildpacks_controller.rb
+++ b/app/controllers/api/v1/buildpacks_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::BuildpacksController < ApplicationController
         {
           "version": b.version,
           # TODO make the host a variable/constant
-          "_link": "https://registry.buildpacks.io/api/v1/buildpacks/#{b.namespace}/#{b.name}/#{b.version}"
+          "_link": "https://#{ENV.fetch('HOSTNAME') {'registry.buildpacks.io'}}/api/v1/buildpacks/#{b.namespace}/#{b.name}/#{b.version}"
         }
       end
 

--- a/app/controllers/api/v1/buildpacks_controller.rb
+++ b/app/controllers/api/v1/buildpacks_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::BuildpacksController < ApplicationController
         {
           "version": b.version,
           # TODO make the host a variable/constant
-          "_link": "https://#{ENV.fetch('HOSTNAME') {'registry.buildpacks.io'}}/api/v1/buildpacks/#{b.namespace}/#{b.name}/#{b.version}"
+          "_link": "https://#{ENV.fetch('CNB_API_HOST') {'registry.buildpacks.io'}}/api/v1/buildpacks/#{b.namespace}/#{b.name}/#{b.version}"
         }
       end
 


### PR DESCRIPTION
## Changes
- Replace hardcoded hostname with `HOSTNAME` env var, if not found, defaults to  `'registry.buildpacks.io'` (could also be replaced with `request.host`?).

Example with `HOSTNAME=test.localhost`:
![image](https://user-images.githubusercontent.com/34343421/108344294-f8868a80-7202-11eb-89c0-fc9f5093a557.png)

Fixes #37 