### PR TITLE
Limit the size of the version dropdown menu in details page 

### DIFF
--- a/app/javascript/components/buildpack/Detail.scss
+++ b/app/javascript/components/buildpack/Detail.scss
@@ -70,3 +70,8 @@ code {
     justify-content: flex-start;
     flex-flow: row wrap;
 }
+
+.dropdown-menu {
+    max-height: 25em;
+    overflow-y: auto;
+}


### PR DESCRIPTION
A very long list of versions would cause the page to overflow and shift around as the page scrollbar appears and disappears.
## Changes
- Limit the size of the version dropdown to `25em`
- Allow overflow within the dropdown

Old (when overflow is required, the entire page scrolls):
![image](https://user-images.githubusercontent.com/34343421/108529320-5cd84580-72fa-11eb-961d-198095cfd709.png)

New (when overflow is required, a scrollbar appears inside the dropdown):
![image](https://user-images.githubusercontent.com/34343421/108529420-78435080-72fa-11eb-90fd-148053a1ae87.png)

New (when overflow is not required, looks the same as the old version):
![image](https://user-images.githubusercontent.com/34343421/108529562-990ba600-72fa-11eb-88d4-30f70f75f04e.png)

