### PR TITLE
Fix node-sass build failure by pinning to Node.js 14

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,13 @@
+{
+  "buildpacks": [
+    {
+      "url": "heroku/go"
+    },
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "search",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": "14.x"
+  },
   "scripts": {
     "start": "node ./bin/www",
     "index": "node ./bin/indexer"


### PR DESCRIPTION
Recent Heroku CI builds are failing with `node-sass` compilation errors as shown here: https://dashboard.heroku.com/apps/cnb-registry-api-staging/activity/builds/061da7cf-2133-4eaf-8e55-05001275b590

Heroku's default Node.js version has recently changed to the `16.x` line. This project uses `node-sass@4.14.1`, which does not compile against Node.js 16 or better. `node-sass@6.0.1` does compile on on Node.js 16, but `node-sass` is a nested dependency of `@rails/webpacker`, which is retired and has no released version with a newer `node-sass`. I think it's more straightforward to pin to Node.js 14.x for now.

This change requires the buildpack order to be specified. The `heroku/ruby` buildpack will try to install the latest Node.js if it does not detect one. We want the `heroku/nodejs` buildpack to run first, so that it installs the correct version (14.x). The staging app already has the order set correctly. The `app.json` changes ensure that review apps use the correct order, too.