### PR TITLE
Cast buildpack semver parts to integer when sorting

### DIFF
--- a/app/controllers/api/v1/buildpacks_controller.rb
+++ b/app/controllers/api/v1/buildpacks_controller.rb
@@ -16,9 +16,9 @@ class Api::V1::BuildpacksController < ApplicationController
       :id
     ).
     where(buildpack_params).order(
-      version_major: :desc,
-      version_minor: :desc,
-      version_patch: :desc,
+      'version_major::integer DESC',
+      'version_minor::integer DESC',
+      'version_patch::integer DESC',
     )
 
     if buildpacks.empty?

--- a/test/controllers/api/v1/buildpacks_controller_test.rb
+++ b/test/controllers/api/v1/buildpacks_controller_test.rb
@@ -8,15 +8,15 @@ class Api::V1::BuildpacksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 2, b.size
     assert_equal 'example', b['latest']['namespace']
     assert_equal 'first', b['latest']['name']
-    assert_equal '1.0.0', b['latest']['version']
+    assert_equal '1.10.0', b['latest']['version']
   end
 
   test "should get show" do
-    get "/api/v1/buildpacks/example/first/1.0.0"
+    get "/api/v1/buildpacks/example/first/1.9.0"
     assert_response :success
     b = JSON.parse(response.body)
     assert_equal 'example', b['namespace']
     assert_equal 'first', b['name']
-    assert_equal '1.0.0', b['version']
+    assert_equal '1.9.0', b['version']
   end
 end

--- a/test/fixtures/buildpacks.yml
+++ b/test/fixtures/buildpacks.yml
@@ -3,13 +3,16 @@
 one:
   namespace: example
   name: first
-  version: "1.0.0"
+  version: "1.9.0"
   addr: MyString
   yanked: false
   description: MyText
   homepage: MyText
   licenses: [MyText]
   stacks: [MyText]
+  version_major: "1"
+  version_minor: "9"
+  version_patch: "0"
 
 two:
   namespace: example
@@ -21,3 +24,20 @@ two:
   homepage: MyText
   licenses: [MyText]
   stacks: [MyText]
+  version_major: "1"
+  version_minor: "0"
+  version_patch: "0"
+
+three:
+  namespace: example
+  name: first
+  version: "1.10.0"
+  addr: MyString
+  yanked: false
+  description: MyText
+  homepage: MyText
+  licenses: [MyText]
+  stacks: [MyText]
+  version_major: "1"
+  version_minor: "10"
+  version_patch: "0"

--- a/test/models/buildpack_test.rb
+++ b/test/models/buildpack_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class BuildpackTest < ActiveSupport::TestCase
   test "search" do
     b = Buildpack.search("example")
-    assert_equal 2, b.size
+    assert_equal 3, b.size
     assert_equal 'example', b[0].namespace
   end
 end


### PR DESCRIPTION
I'm not sure that this is the right thing to do, but the current sorting mechanism does a string sort on the semver parts of a buildpack version. This results in an api response for a buildpack with a version series like `[0.8.0, 0.9.0, 0.10.0]` that specifies `0.9.0` as the latest version instead of `0.10.0`.

For a real world example, check out the response for https://cnb-registry-api-staging.herokuapp.com//api/v1/buildpacks/paketo-buildpacks/python, which looks like the following:

```json
{
  "latest": {
    "description": "",
    "homepage": "",
    "id": "65ae76da-0928-4635-9738-05100e8a82a5",
    "licenses": null,
    "name": "python",
    "namespace": "paketo-buildpacks",
    "stacks": [
      "io.buildpacks.stacks.bionic"
    ],
    "version": "0.9.0"
  },
  "versions": [
    {
      "_link": "https://cnb-registry-api-staging.herokuapp.com//api/v1/buildpacks/paketo-buildpacks/python/0.9.0",
      "version": "0.9.0"
    },
    {
      "_link": "https://cnb-registry-api-staging.herokuapp.com//api/v1/buildpacks/paketo-buildpacks/python/0.8.1",
      "version": "0.8.1"
    },
    {
      "_link": "https://cnb-registry-api-staging.herokuapp.com//api/v1/buildpacks/paketo-buildpacks/python/0.8.0",
      "version": "0.8.0"
    },
    {
      "_link": "https://cnb-registry-api-staging.herokuapp.com//api/v1/buildpacks/paketo-buildpacks/python/0.10.0",
      "version": "0.10.0"
    }
  ]
}
```