### PR TITLE
Throttle indexer to avoid 429s from regsitry

### DIFF
--- a/cmd/index-buildpacks/main.go
+++ b/cmd/index-buildpacks/main.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/lib/pq"
 
@@ -70,7 +71,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	buildIndex(entries)
+	numOfEntries := len(entries)
+	start := 0
+	sliceSize := 100
+	for start+sliceSize < numOfEntries {
+		buildIndex(entries[start : start+sliceSize])
+		fmt.Println("at=index_buildpack level=info msg='sleep(5) to avoid 429'")
+		time.Sleep(5 * time.Second) // sleep to avoid 429 from registry
+		start = start + sliceSize
+	}
+	buildIndex(entries[start:numOfEntries])
 	fmt.Println("at=index_buildpack level=info msg='done updating index'")
 }
 


### PR DESCRIPTION
Prevent periodic errors like:

```
2022-09-02T15:15:07.583863+00:00 app[index.1]: at=handleMetadata level=warn msg='failed to fetch config' entry='paketo-buildpacks/java-native-image@7.13.0' reason='GET https://gcr.io/v2/token?scope=repository%3Apaketo-buildpacks%2Fjava-native-image%3Apull&service=gcr.io: unexpected status code 429 Too Many Requests: Quota Exceeded.'
```