### PR TITLE
Don't re-index when upstream index is unchanged

### DIFF
--- a/bin/indexer
+++ b/bin/indexer
@@ -4,24 +4,30 @@ const fs = require('fs');
 const execa = require('execa');
 const path = require('path');
 const os = require('os');
+const reindex_delay = process.env.REINDEX_DELAY || 300000;
 
 (async () => {
     let tempPath = execa.sync('mktemp', ['-d']).stdout
     let repoPath = path.join(tempPath, 'tmp')
     let indexPath = path.join(tempPath, "index.json")
+    let lastSha = "";
+    let currentSha = "";
     while (true) {
         console.log('at=main level=info msg="trying to update registry-index repo"');
-        const success = await createUpdateRepo(repoPath);
-        if (success) {
+        currentSha = await createUpdateRepo(repoPath);
+        if (!currentSha) {
+            console.log('at=main level=warn msg="failed to update registry-index repo"');
+        } else if (currentSha === lastSha) {
+            console.log('at=main level=info msg="registry-index repo unchanged"');
+        } else {
             console.log('at=main level=info msg="building index config data cache"');
             fs.writeFileSync(indexPath, JSON.stringify(getNormalisedRegistry(repoPath)))
             console.log('at=main level=info msg="serialized index to file"');
             await buildIndex(indexPath)
             console.log('at=main level=debug msg="done building index config data cache"');
-        } else {
-            console.log('at=main level=warn msg="failed to update registry-index repo"');
+            lastSha = currentSha;
         }
-        await sleep(300000); // wait 5 minutes
+        await sleep(reindex_delay); // wait some time before trying again
     }
 })();
 
@@ -86,7 +92,7 @@ async function createUpdateRepo(repoPath) {
                 await execa('git', ['-C', `${repoPath}`, 'pull']);
             } catch (error) {
                 console.error(error);
-                return false;
+                return;
             }
         } else {
             fs.mkdirSync(repoPath);
@@ -94,8 +100,13 @@ async function createUpdateRepo(repoPath) {
         }
     } catch (err) {
         console.error(err);
-        return false;
+        return;
     }
 
-    return true;
+    try {
+      let cmd = await execa('git', ['rev-parse', 'HEAD']);
+      return cmd.stdout;
+    } catch(err) {
+      console.error(err);
+    }
 }

--- a/bin/indexer
+++ b/bin/indexer
@@ -4,7 +4,7 @@ const fs = require('fs');
 const execa = require('execa');
 const path = require('path');
 const os = require('os');
-const reindex_delay = process.env.REINDEX_DELAY || 300000;
+const reindex_delay = process.env.REINDEX_DELAY || 90000;
 
 (async () => {
     await registryLogin();

--- a/bin/indexer
+++ b/bin/indexer
@@ -105,7 +105,7 @@ async function createUpdateRepo(repoPath) {
     }
 
     try {
-      const cmd = await execa('git', ['rev-parse', 'HEAD']);
+      const cmd = await execa('git', ['-C', `${repoPath}`, 'rev-parse', 'HEAD']);
       return cmd.stdout.trim();
     } catch(err) {
       console.error(err);

--- a/bin/indexer
+++ b/bin/indexer
@@ -104,8 +104,8 @@ async function createUpdateRepo(repoPath) {
     }
 
     try {
-      let cmd = await execa('git', ['rev-parse', 'HEAD']);
-      return cmd.stdout;
+      const cmd = await execa('git', ['rev-parse', 'HEAD']);
+      return cmd.stdout.trim();
     } catch(err) {
       console.error(err);
     }


### PR DESCRIPTION
This PR aims to greatly reduce the number of unnecessary docker pulls and postgres writes we make. We don't need to rebuild the entire `buildpacks` table and re-fetch every docker image if there have been no new changes to the upstream index. In this PR, we keep track of the last commit sha of that we fully indexed, and skip the process entirely if the sha hasn't changed.

This should lower the number of times we perform a full reindex each day from greater than 100 to less than 10. This should lower our impact on upstream registries (like dockerhub and ECR) and make rate limiting less frequent.

I've also changed the delay between re-indexing from 5 minutes to 1.5 minutes, since most of the time, there won't be a new commit, so there won't be anything to do. This should reduce the time for a change to appear in the registry api / website by a few minutes.

Related #114 
Fixes #113 