### PR TITLE
Update image URIs too when reindexing

### DIFF
--- a/cmd/index-buildpacks/main.go
+++ b/cmd/index-buildpacks/main.go
@@ -189,6 +189,7 @@ VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, now(), now())
 ON CONFLICT (namespace, name, version)
 DO
 	 UPDATE SET
+		 addr = $4,
 		 homepage = $5,
 		 description = $6,
 		 licenses = $7,


### PR DESCRIPTION
Previously, if a specific buildpack-version combination existed in the index already, all but the `addr` and `created_at` fields would be updated if they had changed.

Now the `addr` field is updated too, leaving the `created_at` field as the only one not updated.

This ensures that the changes in buildpacks/registry-index#5767 are correctly picked up.