### PR TITLE
Redact credentials before printing to logs

### DIFF
--- a/cmd/index-buildpacks/main.go
+++ b/cmd/index-buildpacks/main.go
@@ -85,6 +85,28 @@ func main() {
 	fmt.Println("at=index_buildpack level=info msg='done updating index'")
 }
 
+func RedactString(authConfig *authn.AuthConfig, inputStr string) string {
+	outputStr := inputStr // Start with the original string
+
+	if authConfig.IdentityToken != "" {
+		outputStr = strings.ReplaceAll(outputStr, authConfig.IdentityToken, "<REDACTED>")
+	}
+	if authConfig.RegistryToken != "" {
+		outputStr = strings.ReplaceAll(outputStr, authConfig.RegistryToken, "<REDACTED>")
+	}
+	if authConfig.Password != "" {
+		outputStr = strings.ReplaceAll(outputStr, authConfig.Password, "<REDACTED>")
+	}
+	if authConfig.Username != "" {
+		outputStr = strings.ReplaceAll(outputStr, authConfig.Username, "<REDACTED>")
+	}
+	if authConfig.Auth != "" {
+		outputStr = strings.ReplaceAll(outputStr, authConfig.Auth, "<REDACTED>")
+	}
+
+	return outputStr
+}
+
 func buildIndex(entries []Entry) {
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
 	if err != nil {

--- a/cmd/index-buildpacks/main.go
+++ b/cmd/index-buildpacks/main.go
@@ -150,11 +150,15 @@ func FetchBuildpackConfig(e Entry, imageFn ImageFunction) (Metadata, error) {
 		return Metadata{}, err
 	}
 
+	authenticator, err := authn.DefaultKeychain.Resolve(ref.Context())
+	if err != nil {
+		return Metadata{}, errors.New(fmt.Sprintf("Cannot resolve credentials for context %s", ref.Context()))
+	}
 	if _, ok := ref.(name.Digest); !ok {
 		return Metadata{}, errors.New(fmt.Sprintf("address is not a digest: %s", e.Address))
 	}
 
-	image, err := imageFn(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	image, err := imageFn(ref, remote.WithAuth(authenticator))
 	if err != nil {
 		return Metadata{}, err
 	}


### PR DESCRIPTION
Error messages from docker can contain sensitive information such as usernames/passwords. This PR aims to prevent this information from entering the logs:

```
TOOMANYREQUESTS: You have reached your pull rate limit as '<REDACTED>': <REDACTED>.
```
